### PR TITLE
Fix NameError in fallback attention 

### DIFF
--- a/src/tabpfn/model/multi_head_attention.py
+++ b/src/tabpfn/model/multi_head_attention.py
@@ -11,6 +11,13 @@ from torch.utils.checkpoint import checkpoint
 
 from tabpfn.model.memory import support_save_peak_mem_factor
 
+# Fix for erro 'HAVE_FLASH_ATTN' is not defined
+try:
+  import flash_attn
+  HAVE_FLASH_ATTN = True
+except ImportError:
+  HAVE_FLASH_ATTN = False
+
 class MultiHeadAttention(torch.nn.Module):
     _input_size: int
     _output_size: int


### PR DESCRIPTION
# Problem
When the chunked attention implementation falls back to the original attention computation, it encounters a NameError:

```python
NameError: name 'HAVE_FLASH_ATTN' is not defined
```

# Root Cause
The chunked attention logic has three options:
1. Sequence chunking: When sequence length exceeds chunk size
2. Batch chunking: When batch size exceeds limits
3. Fallback to original: When neither chunking condition is met

When the fallback path is triggered, the original compute_attention_heads() method in `multi_head_attention.py` references `HAVE_FLASH_ATTN`.

# Solution
Added the missing variable definition with proper flash attention detection:

```python
try:
    import flash_attn
    HAVE_FLASH_ATTN = True
except ImportError:
    HAVE_FLASH_ATTN = False
```